### PR TITLE
making the accessor private doesnt allow derived class to override the values

### DIFF
--- a/Assets/Scripts/Patterns/AbsPattern.cs
+++ b/Assets/Scripts/Patterns/AbsPattern.cs
@@ -18,7 +18,7 @@ public abstract class AbsPattern : IPatternGenerator
     public bool invertSpin;             // Invert Spin is technically a boolean, 1 = The spin rate will invert once the spin rate hits the Max Spin Rate. 0 = Nothing happens.
     public float rof;                   // This parameter sets the rate at which bullets are fired.
 
-    public IProduct[,] bullets { get; private set; }
+    public IProduct[,] bullets { get; set; }
 
     public IProduct Create(string type, Transform parent, Vector2 pos) => FactoryManager.Instance.FactoryMethod<Bullet>(type, parent, pos);
 


### PR DESCRIPTION
rebased.