### PR TITLE
Adding params to driftoff behaviour inside the update method

### DIFF
--- a/Assets/Scripts/Globals/Globals.cs
+++ b/Assets/Scripts/Globals/Globals.cs
@@ -36,7 +36,7 @@ public static class Globals
     ///// Sequential init time interval
     public static float initializationInterval = 0.7f;
     ///// Wave time interval
-    public static float waveInterval = 5.0f;
+    public static float waveInterval = 2.0f;
     ///// Unit Generation
     public static string boss = "Boss";
     public static string sunflowerFairy = "SunflowerFairy";

--- a/Assets/Scripts/Unit/Unit.cs
+++ b/Assets/Scripts/Unit/Unit.cs
@@ -62,7 +62,14 @@ public abstract class Unit : MonoBehaviour, IDamageable
             bezierCurveT = default;
             hasReachDestination = true;
             //TODO NEED to find a way to make the idl time variable according to the unit AND the level we are currently in OR wave we are at
-            StartCoroutine(DriftOff());
+            if(moveable.GetType() == typeof(MoveableUnitBehaviour))
+            {
+                StartCoroutine(DriftOff());
+            }
+            else
+            {
+                //TODO Add behaviour for units that use cubic bezier curve // spline
+            }
             StartCoroutine(Utilities.Timer(Globals.idleTime, () => { idle = !idle; }));
             return;
         }


### PR DESCRIPTION
Units that follow splines should not be drifting upon reaching waypoint destination